### PR TITLE
New feature

### DIFF
--- a/lib/weekly.js
+++ b/lib/weekly.js
@@ -21,6 +21,7 @@
       allowPastEventCreation: false,
       timezoneOffset: 0,
       utcOffset: ((new Date()).getTimezoneOffset() / -60),
+      selectableDates: null,
       todayFirst: false,
       dayOffset: 0,
       allowOverlap: true,
@@ -49,6 +50,22 @@
       if (this.autoRender) {
         var data = this.update();
         this.emit('weekChange', data);
+      }
+
+      if (this.selectableDates !== null){
+        if ($.type(this.selectableDates) === 'function'){
+          this.canAdd = this.selectableDates;
+        }
+        else {
+          this.canAdd = function (date) {
+            return this.selectableDates.indexOf(date) > -1;
+          };
+        }
+      }
+      else {
+        this.canAdd = function () {
+          return true;
+        };
       }
     },
 
@@ -151,7 +168,7 @@
 
         var currentTarget = $(event.currentTarget);
 
-        if(!this.allowPastEventCreation && dateUtils.isPastDate(currentTarget.data('date'))) {
+        if((!this.allowPastEventCreation && dateUtils.isPastDate(currentTarget.data('date'))) || !this.canAdd(currentTarget.data('date'))) {
           return;
         }
 
@@ -193,7 +210,7 @@
       gridDays.on('click', this.proxy(function(event){
         var target = $(event.currentTarget);
 
-        if(!this.allowPastEventCreation && dateUtils.isPastDate(target.data('date'))) {
+        if((!this.allowPastEventCreation && dateUtils.isPastDate(target.data('date'))) || !this.canAdd(target.data('date'))) {
           return;
         }
 

--- a/test/weekly.test.js
+++ b/test/weekly.test.js
@@ -1166,4 +1166,32 @@ suite('weekly', function() {
       assert.equal(2, el.find('.weekly-event').length);
     });
   });
+
+  suite('Select certain days', function () {
+    test('Using an array as value of selectableDates should add a canAdd function that is an indexOf of that array', function () {
+      var el = $('.weekly').weekly({
+        selectableDates : ['foo', 'bar']
+      });
+      var weekly = el.data('weekly');
+
+      assert.equal(weekly.canAdd('foo'), true);
+      assert.equal(weekly.canAdd('bar'), true);
+      assert.equal(weekly.canAdd('baz'), false);
+    });
+    test('Using a function as value of selectableDate should use the function to determine if the day can be added or not', function () {
+      var called = false,
+        mock = function (date) {
+          called = true;
+          assert.equal(date, 'foo');
+        };
+
+      var el = $('.weekly').weekly({
+        selectableDates : mock
+      });
+      var weekly = el.data('weekly');
+
+      weekly.canAdd('foo');
+      assert.ok(called);
+    });
+  });
 });


### PR DESCRIPTION
It's now possible to pass a new parameter to weekly. The parameter is called `selectableDates`.

If the value of the parameter is an Array, then weekly will match the date against that array and, if found, it will allow the event to be created.

The value can also be a function, in which case the function will receive the date as a parameter and returning `true` will allow the event to be added whereas `false` won't.

Fixes #29
