### PR TITLE
Update to template that sets visibility of previous button to hidden

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -1,7 +1,5 @@
 <div class="weekly-time-navigation">
-  <% if (showPreviousWeekButton) { %>
-  <button class="weekly-previous-week weekly-change-week-button" data-action="prevWeek">&laquo; <span class="week"></span></button>
-  <% } %>
+  <button <% if (showPreviousWeekButton) { %> style="visibility: hidden;" <% } %> class="weekly-previous-week weekly-change-week-button" data-action="prevWeek">&laquo; <span class="week"></span></button>
   <button class="weekly-next-week weekly-change-week-button" data-action="nextWeek"><span class="week"></span> &raquo;</button>
   <button class="weekly-jump-today weekly-change-today-button" data-action="jumpToday">Today</button>
   <div class="weekly-header"></div>

--- a/lib/template.html
+++ b/lib/template.html
@@ -1,5 +1,5 @@
 <div class="weekly-time-navigation">
-  <button <% if (showPreviousWeekButton) { %> style="visibility: hidden;" <% } %> class="weekly-previous-week weekly-change-week-button" data-action="prevWeek">&laquo; <span class="week"></span></button>
+  <button <% if (!showPreviousWeekButton) { %> style="visibility: hidden;" <% } %> class="weekly-previous-week weekly-change-week-button" data-action="prevWeek">&laquo; <span class="week"></span></button>
   <button class="weekly-next-week weekly-change-week-button" data-action="nextWeek"><span class="week"></span> &raquo;</button>
   <button class="weekly-jump-today weekly-change-today-button" data-action="jumpToday">Today</button>
   <div class="weekly-header"></div>


### PR DESCRIPTION
Update to template that sets visibility of previous button to hidden versus remove it from the DOM.  Removing it from the DOM affects the layout of the elements around it causing the date display in the middle
of the header to shift left.